### PR TITLE
Show physloc usage patterns

### DIFF
--- a/PhysicalStorage/physloc_queries.sql
+++ b/PhysicalStorage/physloc_queries.sql
@@ -1,0 +1,14 @@
+-- RAW Physical Location Data Without Formatting Applied
+-- Generally unusable without transforming it from Hex to human readable format 
+SELECT TOP 100 %%physloc%% PhysicalLocationData, cal.*
+FROM SEED.CPTANALIN cal
+
+-- Get Page Location Format Information In Single Column
+SELECT TOP 100 sys.fn_PhysLocFormatter(%%physloc%%) AS PLF, *
+FROM SEED.CPTANALIN cal
+
+-- Break out physical location into usable columns
+SELECT TOP 100 loc.*, cal.*
+FROM SEED.CPTANALIN cal
+	CROSS APPLY sys.fn_PhysLocCracker(%%physloc%%) loc
+ORDER BY loc.file_id, loc.page_id, loc.slot_id

--- a/PhysicalStorage/show_physical_storage_with_randomized_data.sql
+++ b/PhysicalStorage/show_physical_storage_with_randomized_data.sql
@@ -1,0 +1,44 @@
+SET NOCOUNT ON
+
+-- Drop and Recreate Objects As Necessary
+DROP TABLE IF EXISTS dbo.fragmentedData
+DROP TABLE IF EXISTS dbo.recordLimiter
+DROP SEQUENCE IF EXISTS dbo.fragID_seq
+
+CREATE SEQUENCE dbo.fragID_seq START WITH 1 INCREMENT BY 1;
+CREATE TABLE dbo.recordLimiter(ID INT IDENTITY(1,1), someNumber BIT)
+CREATE TABLE dbo.fragmentedData(
+	ID INT NOT NULL, 
+	UnorderedString NVARCHAR(40) NOT NULL,
+	OrderedString UNIQUEIDENTIFIER DEFAULT NEWSEQUENTIALID() NOT NULL,
+	LargeString NVARCHAR(MAX) NOT NULL	
+)
+
+ALTER TABLE dbo.fragmentedData ADD CONSTRAINT PK_fragmentedData_UnorderedString PRIMARY KEY(ID)
+
+-- Stub out a limit for records
+INSERT INTO dbo.recordLimiter(someNumber) 
+SELECT TOP 1000 1 FROM sys.columns c
+
+-- Create Sample Data. At this point the page_id values will increment normally along with the ID column
+INSERT INTO dbo.fragmentedData(ID, UnorderedString, LargeString)
+SELECT (NEXT VALUE FOR dbo.fragID_seq), CAST(NEWID() AS NVARCHAR(40)), REPLICATE(CAST(NEWID() AS NVARCHAR(40)),40)
+FROM dbo.recordLimiter
+
+
+-- Demonstrate ID values increment along with page_id
+SELECT loc.*, f.* 
+FROM dbo.fragmentedData f
+	CROSS APPLY sys.fn_PhysLocCracker(%%physloc%%) loc
+ORDER BY page_id
+
+-- Fragment the data 
+ALTER TABLE dbo.fragmentedData DROP CONSTRAINT PK_fragmentedData_UnorderedString WITH ( ONLINE = OFF )
+ALTER TABLE dbo.fragmentedData ADD CONSTRAINT PK_fragmentedData_UnorderedString PRIMARY KEY(UnorderedString)
+
+-- Demonstrate the ID column is now randomly ordered
+SELECT loc.*, f.* 
+FROM dbo.fragmentedData f
+	CROSS APPLY sys.fn_PhysLocCracker(%%physloc%%) loc
+ORDER BY page_id
+


### PR DESCRIPTION
Shows physloc values for randomized data patterns where the page_id will change when data is randomized. 
Future pull request will demonstrate locking behaviors for co-located data